### PR TITLE
fix: return pull request url in response

### DIFF
--- a/server.js
+++ b/server.js
@@ -62,8 +62,8 @@ app.post(
   async (req, res, next) => {
     try {
       const data = await parseData({ ...req.body, ...req.files });
-      await createPullRequest(data);
-      res.send({ status: 200, url: data.html_url });
+      const result = await createPullRequest(data);
+      res.send({ status: 200, url: result.html_url });
     } catch (error) {
       return next(error);
     }


### PR DESCRIPTION
This mistakenly got removed in https://github.com/excalidraw/excalidraw-libraries-automation/pull/3/commits/394ecf5b1668c0ace9336bfc7e09fb7cf5c44da0 hence adding back